### PR TITLE
Update cka-cheatsheet.md

### DIFF
--- a/cheatsheet/cka-cheatsheet.md
+++ b/cheatsheet/cka-cheatsheet.md
@@ -44,8 +44,8 @@ k config current-context           # Verify
 k run pod1 --image=nginx:1.27 $do > pod.yaml
 k create deployment dep1 --image=nginx:1.27 --replicas=3 $do > dep.yaml
 k expose deployment dep1 --port=80 --target-port=80 $do > svc.yaml
-k create job job1 --image=busybox:1.36 -- sh -c "echo done" $do > job.yaml
-k create cronjob cron1 --image=busybox:1.36 --schedule="*/5 * * * *" -- date $do > cron.yaml
+k create job job1 --image=busybox:1.36 $do -- sh -c "echo done" > job.yaml
+k create cronjob cron1 --image=busybox:1.36 --schedule="*/5 * * * *"  $do -- date > cron.yaml
 k create cm my-cm --from-literal=KEY=value
 k create secret generic my-sec --from-literal=PASS=secret
 k create sa my-sa -n <ns>


### PR DESCRIPTION
$do should be before any commands passed as part of the imperative command.

## What does this PR do?



## Type of change

- [ ] Bug fix (broken command, invalid YAML, dead link)
- [ ] New content (exercise, skeleton, troubleshooting scenario)
- [*] Documentation update (README, comments, wording)
- [ ] Chore (CI, tooling, repo housekeeping)

## Which CKA domain does this relate to?

- [ ] Storage (10%)
- [ ] Troubleshooting (30%)
- [ ] Workloads & Scheduling (15%)
- [ ] Cluster Architecture, Installation & Configuration (25%)
- [ ] Services & Networking (20%)
- [*] N/A

## Checklist

- [ ] I ran `bash scripts/validate-local.sh` with no errors
- [*] I tested any YAML/commands on Kubernetes v1.35
- [ ] I did not include real CKA exam questions
- [ ] I followed the writing style (first-person, casual, no emojis, no AI filler)
- [*] I used the repo aliases (`k`, `$do`, `$now`) where applicable
- [ ] I verified all links point to existing files or valid URLs
